### PR TITLE
Create run-main.yml

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -1,0 +1,39 @@
+name: Run main.py in Container
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  schedule: # Runs the workflow periodically
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: python:3.9
+        options: --user 1001
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run script
+      env:
+        REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}=
+        REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+        REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
+        OUTPUT_DIR: "${{ github.workspace }}/output"
+      run: |
+        python main.py


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate running the `main.py` script in a containerized environment. The workflow is designed to be triggered manually or run on a daily schedule.

Key changes include:

* [`.github/workflows/run-main.yml`](diffhunk://#diff-ecf6850ef3500a2ca82dc29144fe1e20f9992dd4cbb0b5580274b799dd6ce707R1-R39): Added a new workflow configuration to run `main.py` in a Docker container with Python 3.9. This workflow can be triggered manually or scheduled to run daily at midnight UTC.main.pyを定期的またはトリガーに応じて実行するワークフロー