### PR TITLE
nookリポジトリクローンの追加

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -22,12 +22,15 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+      
+    - name: Clone nook repository
+      run: git clone https://github.com/masahito-uwamichi/nook.git
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
+        pip install -r nook/requirements.txt
+        pip install -r nook/requirements-dev.txt
 
     - name: Run script
       env:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to clone the `nook` repository and update the installation of dependencies.

Changes to the workflow:

* [`.github/workflows/run-main.yml`](diffhunk://#diff-ecf6850ef3500a2ca82dc29144fe1e20f9992dd4cbb0b5580274b799dd6ce707R26-R33): Added a step to clone the `nook` repository.
* [`.github/workflows/run-main.yml`](diffhunk://#diff-ecf6850ef3500a2ca82dc29144fe1e20f9992dd4cbb0b5580274b799dd6ce707R26-R33): Updated the paths for installing dependencies to use the `nook` directory.