### PR TITLE
main.py実行時のフォルダをnook内と明示

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -33,6 +33,7 @@ jobs:
         pip install -r nook/requirements-dev.txt
 
     - name: Run script
+      working-directory: nook
       env:
         REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}=
         REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/run-main.yml` file. The change sets the working directory to `nook` when running the script.

* [`.github/workflows/run-main.yml`](diffhunk://#diff-ecf6850ef3500a2ca82dc29144fe1e20f9992dd4cbb0b5580274b799dd6ce707R36): Added `working-directory: nook` to the `Run script` step.