### PR TITLE
python3.10に変更

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       docker:
-        image: python:3.9
+        image: python:3.10
         options: --user 1001
 
     steps:
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
       
     - name: Clone nook repository
       run: git clone https://github.com/masahito-uwamichi/nook.git


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/run-main.yml` file to upgrade the Python version used in the CI/CD pipeline from 3.9 to 3.10.

* Updated the Docker image to use Python 3.10 instead of Python 3.9.
* Updated the `setup-python` action to use Python 3.10 instead of Python 3.9.