### PR TITLE
Run main clone

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       docker:
-        image: python:3.10
+        image: python:3.12
         options: --user 1001
 
     steps:
@@ -21,16 +21,17 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.12'
       
     - name: Clone nook repository
       run: git clone https://github.com/masahito-uwamichi/nook.git
 
     - name: Install dependencies
+      working-directory: nook
       run: |
         python -m pip install --upgrade pip
-        pip install -r nook/requirements.txt
-        pip install -r nook/requirements-dev.txt
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
 
     - name: Run script
       working-directory: nook

--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -37,7 +37,7 @@ jobs:
       working-directory: nook
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}=
+        REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
         REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
         REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
         OUTPUT_DIR: "${{ github.workspace }}/output"


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/run-main.yml` file to upgrade the Python version used in the workflow and make some adjustments to the setup and execution steps.

Changes to Python version:

* Updated the Docker image to use Python 3.12 instead of Python 3.10.
* Updated the `setup-python` action to use Python 3.12 instead of Python 3.10.

Adjustments to setup and execution steps:

* Changed the working directory for installing dependencies and running the script to `nook`.
* Simplified the `pip install` commands by removing the `nook/` prefix from the requirements files.
* Corrected the `REDDIT_CLIENT_ID` environment variable by removing the trailing `=`.