### PR TITLE
アウトプットをpushするリポジトリを詳細に明記

### DIFF
--- a/.github/workflows/run-main.yml
+++ b/.github/workflows/run-main.yml
@@ -64,6 +64,6 @@ jobs:
         git add output/
         git commit -m 'Add output files - $COMMIT_DATE'
         git tag $NEW_BRANCH_NAME
-        git push origin $NEW_BRANCH_NAME
+        git push origin HEAD:refs/heads/$NEW_BRANCH_NAME
       env:        
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/run-main.yml` file. The change modifies the Git push command to specify the reference for the new branch.

* [`.github/workflows/run-main.yml`](diffhunk://#diff-ecf6850ef3500a2ca82dc29144fe1e20f9992dd4cbb0b5580274b799dd6ce707L67-R67): Changed the Git push command to use `HEAD:refs/heads/$NEW_BRANCH_NAME` instead of `$NEW_BRANCH_NAME`.